### PR TITLE
rename ExceptionHandler to ExceptionHandlerInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.2.0
+-----
+
+* [BC BREAK] renamed `SensioLabs\RichModelForms\ExceptionHandling\ExceptionHandler` to
+  `SensioLabs\RichModelForms\ExceptionHandling\ExceptionHandlerInterface`
+
 0.1.0
 -----
 

--- a/src/ExceptionHandling/ArgumentTypeMismatchExceptionHandler.php
+++ b/src/ExceptionHandling/ArgumentTypeMismatchExceptionHandler.php
@@ -22,7 +22,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 /**
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
  */
-final class ArgumentTypeMismatchExceptionHandler implements ExceptionHandler
+final class ArgumentTypeMismatchExceptionHandler implements ExceptionHandlerInterface
 {
     private $translator;
     private $translationDomain;

--- a/src/ExceptionHandling/ChainExceptionHandler.php
+++ b/src/ExceptionHandling/ChainExceptionHandler.php
@@ -28,12 +28,12 @@ use Symfony\Component\Form\FormInterface;
  *
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
  */
-final class ChainExceptionHandler implements ExceptionHandler
+final class ChainExceptionHandler implements ExceptionHandlerInterface
 {
     private $exceptionHandlers;
 
     /**
-     * @param ExceptionHandler[] $exceptionHandlers
+     * @param ExceptionHandlerInterface[] $exceptionHandlers
      */
     public function __construct(iterable $exceptionHandlers)
     {

--- a/src/ExceptionHandling/ExceptionHandlerInterface.php
+++ b/src/ExceptionHandling/ExceptionHandlerInterface.php
@@ -30,7 +30,7 @@ use Symfony\Component\Form\FormInterface;
  *
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
  */
-interface ExceptionHandler
+interface ExceptionHandlerInterface
 {
     public function getError(FormInterface $form, $data, \Throwable $e): ?FormError;
 }

--- a/src/ExceptionHandling/ExceptionHandlerRegistry.php
+++ b/src/ExceptionHandling/ExceptionHandlerRegistry.php
@@ -35,7 +35,7 @@ class ExceptionHandlerRegistry
         return isset($this->strategies[$strategy]);
     }
 
-    public function get(string $strategy): ExceptionHandler
+    public function get(string $strategy): ExceptionHandlerInterface
     {
         if (!isset($this->strategies[$strategy])) {
             throw new \InvalidArgumentException(sprintf('The exception handling strategy "%s" is not registered (use one of ["%s"]).', $strategy, implode(', ', array_keys($this->strategies))));

--- a/src/ExceptionHandling/FallbackExceptionHandler.php
+++ b/src/ExceptionHandling/FallbackExceptionHandler.php
@@ -27,7 +27,7 @@ use Symfony\Component\Translation\TranslatorInterface;
  *
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
  */
-final class FallbackExceptionHandler implements ExceptionHandler
+final class FallbackExceptionHandler implements ExceptionHandlerInterface
 {
     private $translator;
     private $translationDomain;

--- a/src/ExceptionHandling/GenericExceptionHandler.php
+++ b/src/ExceptionHandling/GenericExceptionHandler.php
@@ -29,7 +29,7 @@ use Symfony\Component\Form\FormInterface;
  *
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
  */
-final class GenericExceptionHandler implements ExceptionHandler
+final class GenericExceptionHandler implements ExceptionHandlerInterface
 {
     private $handledExceptionClass;
 


### PR DESCRIPTION
This change makes the bundle code in line with what developers are used
to work with in a typical Symfony application where interfaces are
suffixed with "Interface".