### PR TITLE
forbid the data_class option on immutable forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.2.1
+-----
+
+* Raise an error when the `data_class` option is used and the `immutable` option is enabled.
+
 0.2.0
 -----
 

--- a/src/Extension/RichModelFormsTypeExtension.php
+++ b/src/Extension/RichModelFormsTypeExtension.php
@@ -164,6 +164,10 @@ final class RichModelFormsTypeExtension extends AbstractTypeExtension
         });
 
         $resolver->setNormalizer('data_class', function (Options $options, $value) {
+            if (null !== $value && $options['immutable']) {
+                throw new InvalidConfigurationException('The "data_class" option cannot be used on immutable forms.');
+            }
+
             if (!$options['immutable'] && null !== $options['factory'] && \is_string($options['factory'])) {
                 return $options['factory'];
             }

--- a/tests/Extension/RichModelFormsTypeExtensionTest.php
+++ b/tests/Extension/RichModelFormsTypeExtensionTest.php
@@ -201,6 +201,18 @@ class RichModelFormsTypeExtensionTest extends TestCase
         ]);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidConfigurationException
+     */
+    public function testImmutableObjectsDoNotWorkWithDataClasses(): void
+    {
+        $this->configureOptions()->resolve([
+            'data_class' => GrossPrice::class,
+            'factory' => GrossPrice::class,
+            'immutable' => true,
+        ]);
+    }
+
     private function buildForm(FormBuilderInterface $formBuilder, array $options): void
     {
         $this->extension->buildForm($formBuilder, $this->configureOptions()->resolve($options));


### PR DESCRIPTION
The view data of an immutable form is an array. Using the "data_class"
option means that a new object will be instantiated breaking the data
mapping process. But since the Form component never needs to create new
objects when the initial data is empty (this case is handled by the
ValueObjectTransformer) configuring it is useless anyway.

This fixes #45.