### PR TITLE
Allow symfony translation contracts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ env:
 matrix:
   include:
     - php: 7.1
+      env: PHPSTAN_CONFIG=phpstan-php-71.neon
     - php: 7.2
     - php: 7.3
     - php: 7.4
     - php: 7.1
-      env: COMPOSER_OPTIONS="--prefer-lowest --prefer-stable" PHPSTAN_CONFIG=phpstan-low.neon
+      env: COMPOSER_OPTIONS="--prefer-lowest --prefer-stable" PHPSTAN_CONFIG=phpstan-php-71.neon
     - php: 7.2
       env: COMPOSER_OPTIONS=""
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",
-        "phpstan/phpstan": "^0.12.1",
+        "phpstan/phpstan": "^0.12.4",
         "symfony/phpunit-bridge": "^4.4||^5.0",
         "symfony/translation": "^4.4||^5.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,22 +56,7 @@ parameters:
 			path: src/ExceptionHandling/FormExceptionHandler.php
 
 		-
-			message: "#^Property SensioLabs\\\\RichModelForms\\\\ExceptionHandling\\\\FormExceptionHandler\\:\\:\\$translator has unknown class Symfony\\\\Component\\\\Translation\\\\TranslatorInterface as its type\\.$#"
-			count: 1
-			path: src/ExceptionHandling/FormExceptionHandler.php
-
-		-
-			message: "#^Parameter \\$translator of method SensioLabs\\\\RichModelForms\\\\ExceptionHandling\\\\FormExceptionHandler\\:\\:__construct\\(\\) has invalid typehint type Symfony\\\\Component\\\\Translation\\\\TranslatorInterface\\.$#"
-			count: 1
-			path: src/ExceptionHandling/FormExceptionHandler.php
-
-		-
 			message: "#^Method SensioLabs\\\\RichModelForms\\\\ExceptionHandling\\\\FormExceptionHandler\\:\\:handleException\\(\\) has parameter \\$data with no typehint specified\\.$#"
-			count: 1
-			path: src/ExceptionHandling/FormExceptionHandler.php
-
-		-
-			message: "#^Call to method trans\\(\\) on an unknown class Symfony\\\\Component\\\\Translation\\\\TranslatorInterface\\.$#"
 			count: 1
 			path: src/ExceptionHandling/FormExceptionHandler.php
 

--- a/phpstan-php-71.neon
+++ b/phpstan-php-71.neon
@@ -4,17 +4,7 @@ includes:
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method SensioLabs\\\\RichModelForms\\\\DataMapper\\\\DataMapper\\:\\:mapDataToForms\\(\\) has parameter \\$data with no typehint specified\\.$#"
-			count: 1
-			path: src/DataMapper/DataMapper.php
-
-		-
 			message: "#^Parameter \\#2 \\$forms of method Symfony\\\\Component\\\\Form\\\\DataMapperInterface\\:\\:mapDataToForms\\(\\) expects iterable\\<Symfony\\\\Component\\\\Form\\\\FormInterface\\>&Traversable, array\\<int, Symfony\\\\Component\\\\Form\\\\FormInterface\\> given\\.$#"
-			count: 1
-			path: src/DataMapper/DataMapper.php
-
-		-
-			message: "#^Method SensioLabs\\\\RichModelForms\\\\DataMapper\\\\DataMapper\\:\\:mapFormsToData\\(\\) has parameter \\$data with no typehint specified\\.$#"
 			count: 1
 			path: src/DataMapper/DataMapper.php
 

--- a/src/ExceptionHandling/FormExceptionHandler.php
+++ b/src/ExceptionHandling/FormExceptionHandler.php
@@ -16,7 +16,7 @@ namespace SensioLabs\RichModelForms\ExceptionHandling;
 
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>


### PR DESCRIPTION
On a new sf5 installation there is no `TranslatorInterface` in translation component since it has been moved to contracts. This pull request allows to use either of them.