### PR TITLE
update PHPStan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   global:
     - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
     - COMPOSER_OPTIONS="--prefer-stable"
+    - PHPSTAN_CONFIG=phpstan.neon
 
 matrix:
   include:
@@ -19,7 +20,7 @@ matrix:
     - php: 7.3
     - php: 7.4
     - php: 7.1
-      env: COMPOSER_OPTIONS="--prefer-lowest --prefer-stable"
+      env: COMPOSER_OPTIONS="--prefer-lowest --prefer-stable" PHPSTAN_CONFIG=phpstan-low.neon
     - php: 7.2
       env: COMPOSER_OPTIONS=""
 
@@ -33,5 +34,5 @@ install:
 
 script:
   - vendor/bin/php-cs-fixer fix --diff --dry-run
-  - vendor/bin/phpstan analyze -l 6 src
+  - vendor/bin/phpstan analyze -c $PHPSTAN_CONFIG
   - vendor/bin/simple-phpunit

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",
-        "phpstan/phpstan": "^0.10.2",
+        "phpstan/phpstan": "^0.12.1",
         "symfony/phpunit-bridge": "^4.4||^5.0",
         "symfony/translation": "^4.4||^5.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,131 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\DataMapper\\\\PropertyMapperInterface\\:\\:readPropertyValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/DataMapper/PropertyMapperInterface.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\DataMapper\\\\PropertyMapperInterface\\:\\:readPropertyValue\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/DataMapper/PropertyMapperInterface.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\DataMapper\\\\PropertyMapperInterface\\:\\:writePropertyValue\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/DataMapper/PropertyMapperInterface.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\DataMapper\\\\PropertyMapperInterface\\:\\:writePropertyValue\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/DataMapper/PropertyMapperInterface.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\DataTransformer\\\\ValueObjectTransformer\\:\\:getPropertyValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/DataTransformer/ValueObjectTransformer.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\DataTransformer\\\\ValueObjectTransformer\\:\\:getPropertyValue\\(\\) has parameter \\$object with no typehint specified\\.$#"
+			count: 1
+			path: src/DataTransformer/ValueObjectTransformer.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\DataTransformer\\\\ValueObjectTransformer\\:\\:mapExceptionToError\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/DataTransformer/ValueObjectTransformer.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\ExceptionHandling\\\\ArgumentTypeMismatchExceptionHandler\\:\\:getError\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/ExceptionHandling/ArgumentTypeMismatchExceptionHandler.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\ExceptionHandling\\\\ChainExceptionHandler\\:\\:getError\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/ExceptionHandling/ChainExceptionHandler.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\ExceptionHandling\\\\ExceptionHandlerInterface\\:\\:getError\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/ExceptionHandling/ExceptionHandlerInterface.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\ExceptionHandling\\\\FormExceptionHandler\\:\\:mapExceptionToError\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/ExceptionHandling/FormExceptionHandler.php
+
+		-
+			message: "#^Property SensioLabs\\\\RichModelForms\\\\ExceptionHandling\\\\FormExceptionHandler\\:\\:\\$translator has unknown class Symfony\\\\Component\\\\Translation\\\\TranslatorInterface as its type\\.$#"
+			count: 1
+			path: src/ExceptionHandling/FormExceptionHandler.php
+
+		-
+			message: "#^Parameter \\$translator of method SensioLabs\\\\RichModelForms\\\\ExceptionHandling\\\\FormExceptionHandler\\:\\:__construct\\(\\) has invalid typehint type Symfony\\\\Component\\\\Translation\\\\TranslatorInterface\\.$#"
+			count: 1
+			path: src/ExceptionHandling/FormExceptionHandler.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\ExceptionHandling\\\\FormExceptionHandler\\:\\:handleException\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/ExceptionHandling/FormExceptionHandler.php
+
+		-
+			message: "#^Call to method trans\\(\\) on an unknown class Symfony\\\\Component\\\\Translation\\\\TranslatorInterface\\.$#"
+			count: 1
+			path: src/ExceptionHandling/FormExceptionHandler.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\ExceptionHandling\\\\FallbackExceptionHandler\\:\\:getError\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/ExceptionHandling/FallbackExceptionHandler.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\ExceptionHandling\\\\GenericExceptionHandler\\:\\:getError\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/ExceptionHandling/GenericExceptionHandler.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\Instantiator\\\\FormDataInstantiator\\:\\:getData\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Instantiator/FormDataInstantiator.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\Instantiator\\\\FormDataInstantiator\\:\\:getArgumentData\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Instantiator/FormDataInstantiator.php
+
+		-
+			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
+			count: 1
+			path: src/Instantiator/ObjectInstantiator.php
+
+		-
+			message: "#^Cannot call method isPublic\\(\\) on ReflectionMethod\\|null\\.$#"
+			count: 1
+			path: src/Instantiator/ObjectInstantiator.php
+
+		-
+			message: "#^Cannot call method getParameters\\(\\) on ReflectionMethod\\|null\\.$#"
+			count: 1
+			path: src/Instantiator/ObjectInstantiator.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\Instantiator\\\\ObjectInstantiator\\:\\:getData\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Instantiator/ObjectInstantiator.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\Instantiator\\\\ObjectInstantiator\\:\\:getArgumentData\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Instantiator/ObjectInstantiator.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\Instantiator\\\\ViewDataInstantiator\\:\\:getData\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Instantiator/ViewDataInstantiator.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\Instantiator\\\\ViewDataInstantiator\\:\\:getArgumentData\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Instantiator/ViewDataInstantiator.php

--- a/phpstan-low.neon
+++ b/phpstan-low.neon
@@ -1,0 +1,24 @@
+includes:
+    - phpstan.neon
+
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\DataMapper\\\\DataMapper\\:\\:mapDataToForms\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/DataMapper/DataMapper.php
+
+		-
+			message: "#^Parameter \\#2 \\$forms of method Symfony\\\\Component\\\\Form\\\\DataMapperInterface\\:\\:mapDataToForms\\(\\) expects iterable\\<Symfony\\\\Component\\\\Form\\\\FormInterface\\>&Traversable, array\\<int, Symfony\\\\Component\\\\Form\\\\FormInterface\\> given\\.$#"
+			count: 1
+			path: src/DataMapper/DataMapper.php
+
+		-
+			message: "#^Method SensioLabs\\\\RichModelForms\\\\DataMapper\\\\DataMapper\\:\\:mapFormsToData\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/DataMapper/DataMapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$forms of method Symfony\\\\Component\\\\Form\\\\DataMapperInterface\\:\\:mapFormsToData\\(\\) expects iterable\\<Symfony\\\\Component\\\\Form\\\\FormInterface\\>&Traversable, array\\<int, Symfony\\\\Component\\\\Form\\\\FormInterface\\> given\\.$#"
+			count: 1
+			path: src/DataMapper/DataMapper.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+includes:
+    - phar://vendor/phpstan/phpstan/phpstan.phar/conf/config.levelmax.neon
+    - phpstan-baseline.neon
+
+parameters:
+    checkMissingIterableValueType: false
+    inferPrivatePropertyTypeFromConstructor: true
+    paths:
+        - src

--- a/src/DataTransformer/ValueObjectTransformer.php
+++ b/src/DataTransformer/ValueObjectTransformer.php
@@ -33,7 +33,6 @@ class ValueObjectTransformer implements DataTransformerInterface
 
     private $propertyAccessor;
     private $form;
-    private $exceptionToErrorMapper;
 
     public function __construct(ExceptionHandlerRegistry $exceptionHandlerRegistry, PropertyAccessorInterface $propertyAccessor, FormBuilderInterface $form)
     {

--- a/src/Instantiator/FormDataInstantiator.php
+++ b/src/Instantiator/FormDataInstantiator.php
@@ -23,6 +23,9 @@ class FormDataInstantiator extends ObjectInstantiator
 {
     private $form;
 
+    /**
+     * @param string|\Closure|callable $factory
+     */
     public function __construct($factory, FormInterface $form)
     {
         parent::__construct($factory);

--- a/src/Instantiator/ObjectInstantiator.php
+++ b/src/Instantiator/ObjectInstantiator.php
@@ -23,11 +23,17 @@ abstract class ObjectInstantiator
 {
     private $factory;
 
+    /**
+     * @param string|\Closure|callable $factory
+     */
     public function __construct($factory)
     {
         $this->factory = $factory;
     }
 
+    /**
+     * @return object
+     */
     public function instantiateObject()
     {
         if ($this->factory instanceof \Closure) {
@@ -63,9 +69,7 @@ abstract class ObjectInstantiator
             return new $this->factory(...$arguments);
         }
 
-        if (\is_array($this->factory) && \is_callable($this->factory)) {
-            return ($this->factory)(...$arguments);
-        }
+        return ($this->factory)(...$arguments);
     }
 
     abstract protected function isCompoundForm(): bool;

--- a/src/Instantiator/ViewDataInstantiator.php
+++ b/src/Instantiator/ViewDataInstantiator.php
@@ -24,6 +24,9 @@ class ViewDataInstantiator extends ObjectInstantiator
     private $form;
     private $viewData;
 
+    /**
+     * @param array<string,mixed> $viewData
+     */
     public function __construct(FormBuilderInterface $form, $viewData)
     {
         parent::__construct($form->getFormConfig()->getOption('factory'));


### PR DESCRIPTION
Uses a more recent PHPStan version that does not depend on Symfony
components and thus no longer prevents installing Symfony 5 components
when composer installs dependencies with development dependencies.