### PR TITLE
Prevent mapping extra fields in form for entity

### DIFF
--- a/src/DataTransformer/ValueObjectTransformer.php
+++ b/src/DataTransformer/ValueObjectTransformer.php
@@ -54,6 +54,11 @@ class ValueObjectTransformer implements DataTransformerInterface
                 if ($child instanceof ButtonBuilder) {
                     continue;
                 }
+
+                if (!$child->getOption('mapped')) {
+                    continue;
+                }
+
                 $viewData[$name] = $this->getPropertyValue($child, $value);
             }
 

--- a/tests/Fixtures/Form/GrossPriceType.php
+++ b/tests/Fixtures/Form/GrossPriceType.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Exception\InvalidConfigurationException;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -40,6 +41,12 @@ class GrossPriceType extends AbstractType
             ])
         ;
 
+        if ($options['extra_field']) {
+            $builder->add('extra_field', TextType::class, [
+                'mapped' => $options['map_extra_field'],
+            ]);
+        }
+
         if ($options['include_button']) {
             $builder->add('submit', SubmitType::class);
         }
@@ -48,6 +55,8 @@ class GrossPriceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefault('data_class', null);
+        $resolver->setDefault('extra_field', false);
         $resolver->setDefault('include_button', false);
+        $resolver->setDefault('map_extra_field', false);
     }
 }


### PR DESCRIPTION
I have additional fields in form for creating new Entity. But default `mapped` option not work in `SensioLabs\RichModelForms\DataTransformer\ValueObjectTransformer`. Any usages of `read_property_path`/`write_property_path`/`property_mapper` does not help

simple example:

```php
public function buildForm(FormBuilderInterface $builder, array $options): void
{
    $builder
        ... // here are entity fields
        ->add('extra_field', SomeType::class, [
            'mapped' => false,
        ])
    ;
}
```

After request handling i catch `NoSuchPropertyException` for `getExtraField()` method.