### PR TITLE
Support `factory_argument` form option

### DIFF
--- a/src/Extension/RichModelFormsTypeExtension.php
+++ b/src/Extension/RichModelFormsTypeExtension.php
@@ -140,6 +140,8 @@ final class RichModelFormsTypeExtension extends AbstractTypeExtension
 
             return $value;
         });
+        $resolver->setDefault('factory_argument', null);
+        $resolver->setAllowedTypes('factory_argument', ['null', 'string']);
 
         $resolver->setDefault('immutable', false);
         $resolver->setAllowedTypes('immutable', 'bool');

--- a/src/Instantiator/FormDataInstantiator.php
+++ b/src/Instantiator/FormDataInstantiator.php
@@ -55,6 +55,15 @@ class FormDataInstantiator extends ObjectInstantiator
 
     protected function getArgumentData(string $argument)
     {
+        if (!$this->form->has($argument)) {
+            foreach ($this->form as $childForm) {
+                $factoryArgument = $childForm->getConfig()->getOption('factory_argument');
+                if ((string) $factoryArgument === $argument) {
+                    return $childForm->getData();
+                }
+            }
+        }
+
         return $this->form->get($argument)->getData();
     }
 }

--- a/src/Instantiator/ViewDataInstantiator.php
+++ b/src/Instantiator/ViewDataInstantiator.php
@@ -23,6 +23,7 @@ class ViewDataInstantiator extends ObjectInstantiator
 {
     private $form;
     private $viewData;
+    private $formNameForArgument;
 
     /**
      * @param array<string,mixed> $viewData
@@ -33,6 +34,11 @@ class ViewDataInstantiator extends ObjectInstantiator
 
         $this->form = $form;
         $this->viewData = $viewData;
+        $this->formNameForArgument = [];
+
+        foreach ($form as $name => $child) {
+            $this->formNameForArgument[$child->getOption('factory_argument') ?? $child->getName()] = $child->getName();
+        }
     }
 
     protected function isCompoundForm(): bool
@@ -47,6 +53,6 @@ class ViewDataInstantiator extends ObjectInstantiator
 
     protected function getArgumentData(string $argument)
     {
-        return $this->viewData[$argument] ?? null;
+        return $this->viewData[$this->formNameForArgument[$argument]] ?? null;
     }
 }

--- a/tests/Integration/FactoryTest.php
+++ b/tests/Integration/FactoryTest.php
@@ -137,4 +137,22 @@ class FactoryTest extends AbstractDataMapperTest
         $this->assertSame(500, $grossPrice->amount());
         $this->assertSame(7, $grossPrice->taxRate());
     }
+
+    public function testInitializeCompoundFormWithPropertyPath(): void
+    {
+        $form = $this->createForm(GrossPriceType::class, null, [
+            'factory' => GrossPrice::class,
+            'data_class' => GrossPrice::class,
+            'tax_rate_field_name' => 'tax',
+            'tax_rate_field_options' => [
+                'factory_argument' => 'taxRate',
+            ],
+        ]);
+        $form->submit([
+            'amount' => '500',
+            'tax' => '7',
+        ]);
+
+        $this->assertEquals(new GrossPrice(500, 7), $form->getData());
+    }
 }

--- a/tests/Integration/ValueObjectsTest.php
+++ b/tests/Integration/ValueObjectsTest.php
@@ -211,6 +211,29 @@ class ValueObjectsTest extends TestCase
         $this->assertSame(7, $grossPrice->taxRate());
     }
 
+    public function testReverseTransformCompoundRootFormToNormDataUsingConstructorWithArgumentName(): void
+    {
+        $form = $this->createForm(GrossPriceType::class, null, [
+            'factory' => GrossPrice::class,
+            'immutable' => true,
+            'tax_rate_field_name' => 'tax',
+            'tax_rate_field_options' => [
+                'factory_argument' => 'taxRate',
+                'read_property_path' => 'taxRate',
+            ],
+        ]);
+        $form->submit([
+            'amount' => '650',
+            'tax' => '7',
+        ]);
+
+        $grossPrice = $form->getData();
+
+        $this->assertInstanceOf(GrossPrice::class, $grossPrice);
+        $this->assertSame(650, $grossPrice->amount());
+        $this->assertSame(7, $grossPrice->taxRate());
+    }
+
     public function testReverseTransformCompoundRootFormToNormDataUsingFactoryMethod(): void
     {
         $form = $this->createForm(GrossPriceType::class, new GrossPrice(500, 19), [
@@ -220,6 +243,29 @@ class ValueObjectsTest extends TestCase
         $form->submit([
             'amount' => '650',
             'taxRate' => '7',
+        ]);
+
+        $grossPrice = $form->getData();
+
+        $this->assertInstanceOf(GrossPrice::class, $grossPrice);
+        $this->assertSame(650, $grossPrice->amount());
+        $this->assertSame(7, $grossPrice->taxRate());
+    }
+
+    public function testReverseTransformCompoundRootFormToNormDataUsingFactoryMethodWithArgumentName(): void
+    {
+        $form = $this->createForm(GrossPriceType::class, null, [
+            'factory' => [GrossPrice::class, 'withAmountAndTaxRate'],
+            'immutable' => true,
+            'tax_rate_field_name' => 'tax',
+            'tax_rate_field_options' => [
+                'factory_argument' => 'taxRate',
+                'read_property_path' => 'taxRate',
+            ],
+        ]);
+        $form->submit([
+            'amount' => '650',
+            'tax' => '7',
         ]);
 
         $grossPrice = $form->getData();


### PR DESCRIPTION
Support for `property_path` form option.

Example: 
```php
// the model
class Product {
    private ProductId $productId;

    public function __construct(ProductId $productId)
    {
        $this->productId = $productId;
    }
}
```

```php
// the form
$builder->add('id', null, ['factory_argument' => 'productId']);
```